### PR TITLE
Additional params --bone-mass --muscle-mass

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Aliases:
 Flags:
       --bmi float               Set your BMI - body mass index
   -b, --bone float              Set your bone mass in percent
+      --bone-mass float         Set your bone mass in kilograms (use --bone or --bone-mass)
   -c, --calories float          Set your caloric intake
   -e, --email string            Email of the Garmin account
   -f, --fat float               Set your fat in percent
@@ -72,6 +73,7 @@ Flags:
       --hydration float         Set your hydration in percent
       --metabolic-age float     Set your metabolic age
   -m, --muscle float            Set your muscle mass in percent
+      --muscle-mass float       Set your muscle mass in kilograms (use -muscle or --muscle-mass)
   -p, --password string         Password of the Garmin account
       --physique-rating float   Set your physique rating (valid values: 1-9)
   -t, --unix-timestamp int      Set the timestamp of the measurement (default -1)

--- a/bodycomposition.go
+++ b/bodycomposition.go
@@ -14,8 +14,8 @@ type BodyComposition struct {
 	Weight            float64
 	PercentFat        float64
 	PercentHydration  float64
-	PercentBone       float64
-	PercentMuscle     float64
+	BoneMass          float64
+	MuscleMass        float64
 	VisceralFatRating float64
 	PhysiqueRating    float64
 	MetabolicAge      float64
@@ -40,8 +40,8 @@ func (bc BodyComposition) writeFitFile(writer io.Writer) error {
 			Weight:            fit.Weight(bc.Weight * 100),
 			PercentFat:        uint16(bc.PercentFat * 100),
 			PercentHydration:  uint16(bc.PercentHydration * 100),
-			BoneMass:          uint16(bc.Weight * bc.PercentBone),
-			MuscleMass:        uint16(bc.Weight * bc.PercentMuscle),
+			BoneMass:          uint16(bc.BoneMass),
+			MuscleMass:        uint16(bc.MuscleMass),
 			VisceralFatRating: uint8(bc.VisceralFatRating),
 			PhysiqueRating:    uint8(bc.PhysiqueRating),
 			MetabolicAge:      uint8(bc.MetabolicAge),
@@ -54,10 +54,24 @@ func (bc BodyComposition) writeFitFile(writer io.Writer) error {
 }
 
 // NewBodyComposition creates a new BodyComposition instance
-func NewBodyComposition(weight, percentFat, percentHydration, percentBone, percentMuscle, visceralFatRating, physiqueRating, metabolicAge, caloriesActiveMet, bmi float64, timestamp int64) BodyComposition {
+func NewBodyComposition(weight, percentFat, percentHydration, percentBone, boneMass, percentMuscle, muscleMass ,visceralFatRating, physiqueRating, metabolicAge, caloriesActiveMet, bmi float64, timestamp int64) BodyComposition {
 	ts := time.Now()
 	if timestamp != -1 {
 		ts = time.Unix(timestamp, 0)
+	}
+	var bm float64
+	var mm float64
+
+	if(percentBone != 0 ) {
+		bm = weight * percentBone
+	} else {
+		bm = boneMass * 100
+	}
+
+	if(percentMuscle != 0 ) {
+		mm = weight * percentMuscle
+	} else {
+	    mm = muscleMass * 100
 	}
 
 	return BodyComposition{
@@ -65,8 +79,8 @@ func NewBodyComposition(weight, percentFat, percentHydration, percentBone, perce
 		Weight:            weight,
 		PercentFat:        percentFat,
 		PercentHydration:  percentHydration,
-		PercentBone:       percentBone,
-		PercentMuscle:     percentMuscle,
+		BoneMass:          bm,
+		MuscleMass:        mm,
 		VisceralFatRating: visceralFatRating,
 		PhysiqueRating:    physiqueRating,
 		MetabolicAge:      metabolicAge,

--- a/bodycomposition_test.go
+++ b/bodycomposition_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNewBodyCompositionWithDefault(t *testing.T) {
 
-	bc := NewBodyComposition(80, 14.4, 55.2, 37, 45.5, 21, 5, 23, 2250, 12.6, -1)
+	bc := NewBodyComposition(80, 14.4, 55.2, 37, 2.98, 45.5, 55, 21, 5, 23, 2250, 12.6, -1)
 
 	now := time.Now()
 
@@ -26,7 +26,7 @@ func TestNewBodyComposition(t *testing.T) {
 	// set local time to UTC, no matter where executed
 	time.Local = time.UTC
 
-	bc := NewBodyComposition(80, 14.4, 55.2, 37, 45.5, 21, 5, 23, 2250, 12.6, timeStamp)
+	bc := NewBodyComposition(80, 14.4, 55.2, 37, 2.98, 45.5, 55, 21, 5, 23, 2250, 12.6, timeStamp)
 
 	year, month, date := bc.TimeStamp.Date()
 	hour, min, sec := bc.TimeStamp.Clock()

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -26,7 +26,9 @@ var uploadCmd = &cobra.Command{
 		fat, _ := flags.GetFloat64("fat")
 		hydration, _ := flags.GetFloat64("hydration")
 		bone, _ := flags.GetFloat64("bone")
+		boneKg, _ := flags.GetFloat64("bone-mass")
 		muscle, _ := flags.GetFloat64("muscle")
+		muscleKg, _ := flags.GetFloat64("muscle-mass")
 		ts, _ := flags.GetInt64("unix-timestamp")
 		visceralFat, _ := flags.GetFloat64("visceral-fat")
 		metabolicAge, _ := flags.GetFloat64("metabolic-age")
@@ -34,7 +36,7 @@ var uploadCmd = &cobra.Command{
 		calories, _ := flags.GetFloat64("calories")
 		bmi, _ := flags.GetFloat64("bmi")
 
-		bc := bodycomposition.NewBodyComposition(weight, fat, hydration, bone, muscle, visceralFat, physiqueRating, metabolicAge, calories, bmi, ts)
+		bc := bodycomposition.NewBodyComposition(weight, fat, hydration, bone, boneKg, muscle, muscleKg, visceralFat, physiqueRating, metabolicAge, calories, bmi, ts)
 
 		email, _ := cmd.Flags().GetString("email")
 		password, _ := cmd.Flags().GetString("password")
@@ -70,7 +72,9 @@ func init() {
 	flags.Float64P("fat", "f", 0, "Set your fat in percent")
 	flags.Float64("hydration", 0, "Set your hydration in percent")
 	flags.Float64P("bone", "b", 0, "Set your bone mass in percent")
+	flags.Float64("bone-mass", 0, "Set your bone mass in kilograms")
 	flags.Float64P("muscle", "m", 0, "Set your muscle mass in percent")
+	flags.Float64("muscle-mass", 0, "Set your muscle mass in kilograms")
 	flags.Float64P("calories", "c", 0, "Set your caloric intake")
 	flags.Float64("visceral-fat", 0, "Set your visceral fat rating (valid values: 1-60)")
 	flags.Float64("metabolic-age", 0, "Set your metabolic age")

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -24,7 +24,7 @@ func TestUploadWeightToGarminIntegration(t *testing.T) {
 		t.Fatalf("Environment variable %s was not set. This is required.", garminPasswordEnvKey)
 	}
 
-	var bc = NewBodyComposition(80, 14.4, 55.2, 37, 45.5, 21, 5, 23, 2250, 12.6, -1)
+	var bc = NewBodyComposition(80, 14.4, 55.2, 37, 2.98, 45.5, 55, 21, 5, 23, 2250, 12.6, -1)
 
 	err := Upload(email, passWord, bc)
 


### PR DESCRIPTION
Hi David, 

I added input of bone mass and muscle mass in kilograms (via --bone-mass and --muscle-mass). My scale gives me these values in kilograms, So I added this extra params so as not to convert it to percentages. I think it might be useful for others as well.

Best regards,
Łukasz